### PR TITLE
Improve student activity registration systemAccelerate with copilot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pytest
+httpx

--- a/src/app.py
+++ b/src/app.py
@@ -108,3 +108,22 @@ def signup_for_activity(activity_name: str, email: str):
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
+
+
+@app.post("/activities/{activity_name}/unregister")
+def unregister_from_activity(activity_name: str, email: str):
+    """Unregister a student from an activity"""
+    # Validate activity exists
+    if activity_name not in activities:
+        raise HTTPException(status_code=404, detail="Activity not found")
+    
+    # Get the specific activity
+    activity = activities[activity_name]
+
+    # Check if student is registered
+    if email not in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student is not registered for this activity")
+    
+    # Remove student
+    activity["participants"].remove(email)
+    return {"message": f"Unregistered {email} from {activity_name}"}

--- a/src/app.py
+++ b/src/app.py
@@ -38,6 +38,45 @@ activities = {
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+    },
+    # Sports activities
+    "Soccer Team": {
+        "description": "Competitive soccer team practice and matches",
+        "schedule": "Mondays, Wednesdays, 4:00 PM - 6:00 PM",
+        "max_participants": 22,
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+    },
+    "Track and Field": {
+        "description": "Sprint, distance, and field event training",
+        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+        "max_participants": 25,
+        "participants": ["ava@mergington.edu", "isabella@mergington.edu"]
+    },
+    # Artistic activities
+    "Art Club": {
+        "description": "Explore drawing, painting, and mixed media projects",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 18,
+        "participants": ["mia@mergington.edu", "charlotte@mergington.edu"]
+    },
+    "Drama Club": {
+        "description": "Acting, stagecraft, and production for school plays",
+        "schedule": "Fridays, 4:00 PM - 6:00 PM",
+        "max_participants": 24,
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+    },
+    # Intellectual activities
+    "Debate Team": {
+        "description": "Practice public speaking, argumentation, and competitions",
+        "schedule": "Tuesdays, 5:00 PM - 6:30 PM",
+        "max_participants": 16,
+        "participants": ["elijah@mergington.edu", "lucas@mergington.edu"]
+    },
+    "Science Club": {
+        "description": "Hands-on experiments, science fairs, and research projects",
+        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 20,
+        "participants": ["grace@mergington.edu", "henry@mergington.edu"]
     }
 }
 
@@ -62,6 +101,10 @@ def signup_for_activity(activity_name: str, email: str):
     # Get the specific activity
     activity = activities[activity_name]
 
+    # Check if already signed up
+    if email in activity["participants"]:
+        raise HTTPException(status_code=400, detail="Student already signed up for this activity")
+    
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -20,11 +20,19 @@ document.addEventListener("DOMContentLoaded", () => {
 
         const spotsLeft = details.max_participants - details.participants.length;
 
+        const participantsList = details.participants.length > 0
+          ? `<ul class="participants-list">${details.participants.map(p => `<li>${p}</li>`).join("")}</ul>`
+          : `<p class="no-participants"><em>No participants yet</em></p>`;
+
         activityCard.innerHTML = `
           <h4>${name}</h4>
           <p>${details.description}</p>
           <p><strong>Schedule:</strong> ${details.schedule}</p>
           <p><strong>Availability:</strong> ${spotsLeft} spots left</p>
+          <div class="participants-section">
+            <strong>Participants:</strong>
+            ${participantsList}
+          </div>
         `;
 
         activitiesList.appendChild(activityCard);

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -21,7 +21,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const spotsLeft = details.max_participants - details.participants.length;
 
         const participantsList = details.participants.length > 0
-          ? `<ul class="participants-list">${details.participants.map(p => `<li>${p}</li>`).join("")}</ul>`
+          ? `<ul class="participants-list">${details.participants.map(p => `<li><span>${p}</span><button class="delete-btn" data-activity="${name}" data-email="${p}">Delete</button></li>`).join("")}</ul>`
           : `<p class="no-participants"><em>No participants yet</em></p>`;
 
         activityCard.innerHTML = `
@@ -42,6 +42,37 @@ document.addEventListener("DOMContentLoaded", () => {
         option.value = name;
         option.textContent = name;
         activitySelect.appendChild(option);
+      });
+
+      // Add event listeners for delete buttons
+      document.querySelectorAll(".delete-btn").forEach(button => {
+        button.addEventListener("click", async (event) => {
+          event.preventDefault();
+          const activityName = button.getAttribute("data-activity");
+          const email = button.getAttribute("data-email");
+
+          if (confirm(`Are you sure you want to unregister ${email} from ${activityName}?`)) {
+            try {
+              const response = await fetch(
+                `/activities/${encodeURIComponent(activityName)}/unregister?email=${encodeURIComponent(email)}`,
+                {
+                  method: "POST",
+                }
+              );
+
+              if (response.ok) {
+                // Refresh the activities list
+                fetchActivities();
+              } else {
+                const result = await response.json();
+                alert(result.detail || "Failed to unregister participant");
+              }
+            } catch (error) {
+              alert("Failed to unregister participant. Please try again.");
+              console.error("Error unregistering:", error);
+            }
+          }
+        });
       });
     } catch (error) {
       activitiesList.innerHTML = "<p>Failed to load activities. Please try again later.</p>";
@@ -70,6 +101,8 @@ document.addEventListener("DOMContentLoaded", () => {
         messageDiv.textContent = result.message;
         messageDiv.className = "success";
         signupForm.reset();
+        // Refresh activities list to show the new participant
+        fetchActivities();
       } else {
         messageDiv.textContent = result.detail || "An error occurred";
         messageDiv.className = "error";

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -81,14 +81,33 @@ section h3 {
 }
 
 .participants-list {
-  list-style-position: inside;
+  list-style: none;
   margin: 10px 0 0 0;
-  padding-left: 20px;
+  padding-left: 0;
 }
 
 .participants-list li {
-  margin-bottom: 5px;
+  margin-bottom: 8px;
   color: #555;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.delete-btn {
+  background-color: #d32f2f;
+  color: white;
+  border: none;
+  padding: 4px 8px;
+  font-size: 14px;
+  border-radius: 3px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  margin-left: 10px;
+}
+
+.delete-btn:hover {
+  background-color: #b71c1c;
 }
 
 .no-participants {

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -74,6 +74,28 @@ section h3 {
   margin-bottom: 8px;
 }
 
+.participants-section {
+  margin-top: 15px;
+  padding-top: 15px;
+  border-top: 1px solid #e0e0e0;
+}
+
+.participants-list {
+  list-style-position: inside;
+  margin: 10px 0 0 0;
+  padding-left: 20px;
+}
+
+.participants-list li {
+  margin-bottom: 5px;
+  color: #555;
+}
+
+.no-participants {
+  margin: 8px 0;
+  color: #999;
+}
+
 .form-group {
   margin-bottom: 15px;
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Add the src directory to the path so we can import app
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from app import app, activities
+
+
+@pytest.fixture
+def client():
+    """Create a test client for the FastAPI app"""
+    return TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def reset_activities():
+    """Reset activities to initial state before each test"""
+    activities.clear()
+    activities.update({
+        "Chess Club": {
+            "description": "Learn strategies and compete in chess tournaments",
+            "schedule": "Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 12,
+            "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+        },
+        "Programming Class": {
+            "description": "Learn programming fundamentals and build software projects",
+            "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+            "max_participants": 20,
+            "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+        },
+        "Gym Class": {
+            "description": "Physical education and sports activities",
+            "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+            "max_participants": 30,
+            "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        },
+    })

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -1,0 +1,134 @@
+import pytest
+
+
+def test_root_redirect(client):
+    """Test that root path redirects to /static/index.html"""
+    response = client.get("/", follow_redirects=False)
+    assert response.status_code == 307
+    assert response.headers["location"] == "/static/index.html"
+
+
+def test_get_activities(client):
+    """Test getting all activities"""
+    response = client.get("/activities")
+    assert response.status_code == 200
+    data = response.json()
+    
+    assert "Chess Club" in data
+    assert "Programming Class" in data
+    assert "Gym Class" in data
+    
+    # Check Chess Club details
+    chess_club = data["Chess Club"]
+    assert chess_club["description"] == "Learn strategies and compete in chess tournaments"
+    assert chess_club["schedule"] == "Fridays, 3:30 PM - 5:00 PM"
+    assert chess_club["max_participants"] == 12
+    assert len(chess_club["participants"]) == 2
+    assert "michael@mergington.edu" in chess_club["participants"]
+    assert "daniel@mergington.edu" in chess_club["participants"]
+
+
+def test_signup_for_activity_success(client):
+    """Test successful signup for an activity"""
+    response = client.post(
+        "/activities/Chess%20Club/signup?email=newstudent@mergington.edu",
+        follow_redirects=False
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert "Signed up" in data["message"]
+    assert "newstudent@mergington.edu" in data["message"]
+    
+    # Verify the participant was added
+    activities_response = client.get("/activities")
+    activities_data = activities_response.json()
+    assert "newstudent@mergington.edu" in activities_data["Chess Club"]["participants"]
+
+
+def test_signup_for_nonexistent_activity(client):
+    """Test signup for non-existent activity returns 404"""
+    response = client.post(
+        "/activities/Nonexistent%20Activity/signup?email=student@mergington.edu"
+    )
+    
+    assert response.status_code == 404
+    data = response.json()
+    assert "Activity not found" in data["detail"]
+
+
+def test_signup_already_registered(client):
+    """Test signup fails if student is already registered"""
+    response = client.post(
+        "/activities/Chess%20Club/signup?email=michael@mergington.edu"
+    )
+    
+    assert response.status_code == 400
+    data = response.json()
+    assert "already signed up" in data["detail"]
+
+
+def test_unregister_from_activity_success(client):
+    """Test successful unregister from an activity"""
+    response = client.post(
+        "/activities/Chess%20Club/unregister?email=michael@mergington.edu"
+    )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert "Unregistered" in data["message"]
+    assert "michael@mergington.edu" in data["message"]
+    
+    # Verify the participant was removed
+    activities_response = client.get("/activities")
+    activities_data = activities_response.json()
+    assert "michael@mergington.edu" not in activities_data["Chess Club"]["participants"]
+    assert len(activities_data["Chess Club"]["participants"]) == 1
+
+
+def test_unregister_from_nonexistent_activity(client):
+    """Test unregister from non-existent activity returns 404"""
+    response = client.post(
+        "/activities/Nonexistent%20Activity/unregister?email=student@mergington.edu"
+    )
+    
+    assert response.status_code == 404
+    data = response.json()
+    assert "Activity not found" in data["detail"]
+
+
+def test_unregister_not_registered_student(client):
+    """Test unregister fails if student is not registered"""
+    response = client.post(
+        "/activities/Chess%20Club/unregister?email=notregistered@mergington.edu"
+    )
+    
+    assert response.status_code == 400
+    data = response.json()
+    assert "not registered" in data["detail"]
+
+
+def test_signup_and_unregister_flow(client):
+    """Test complete flow of signing up and then unregistering"""
+    email = "testuser@mergington.edu"
+    activity = "Programming%20Class"
+    
+    # Verify user is not in the activity
+    response = client.get("/activities")
+    assert email not in response.json()["Programming Class"]["participants"]
+    
+    # Sign up
+    signup_response = client.post(f"/activities/{activity}/signup?email={email}")
+    assert signup_response.status_code == 200
+    
+    # Verify user is now in the activity
+    response = client.get("/activities")
+    assert email in response.json()["Programming Class"]["participants"]
+    
+    # Unregister
+    unregister_response = client.post(f"/activities/{activity}/unregister?email={email}")
+    assert unregister_response.status_code == 200
+    
+    # Verify user is no longer in the activity
+    response = client.get("/activities")
+    assert email not in response.json()["Programming Class"]["participants"]


### PR DESCRIPTION
This pull request adds support for unregistering participants from activities, enhances the frontend to display participants and enable removal, expands the list of available activities, and introduces automated backend tests for activity management. These changes improve both the user experience and code reliability by allowing users to manage activity participation directly from the UI and ensuring robust backend functionality.

**Backend functionality improvements:**

* Added an `/activities/{activity_name}/unregister` endpoint in `src/app.py` to allow participants to be removed from activities, with validation to prevent unregistering non-participants or from non-existent activities.
* Expanded the `activities` dictionary in `src/app.py` to include additional sports, artistic, and intellectual activities.

**Frontend user experience enhancements:**

* Updated `src/static/app.js` to display participants for each activity, including a "Delete" button next to each participant that allows unregistering them via the new backend endpoint. [[1]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R23-R35) [[2]](diffhunk://#diff-7146e1c8a61ac4e715182863a67d7a5a3178a73033e8344cd24f1c67787236e3R46-R76)
* Refreshed the activities list in the UI after a signup or unregister action to reflect the latest participant data.
* Improved the styling in `src/static/styles.css` for the participants section, participant list, and delete button for a clearer and more user-friendly interface.

**Automated testing and reliability:**

* Added backend tests in `tests/test_activities.py` to cover activity listing, signup, unregister, error cases, and end-to-end participant management flows, with test fixtures for consistent state setup in `tests/conftest.py`. [[1]](diffhunk://#diff-1296adb14376e606bd4f15dbb75f86149ab573e22b6ad4987870b03bc16dbcf5R1-R134) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R1-R42)